### PR TITLE
Update docs for n8n usage

### DIFF
--- a/ADVANCED_README.md
+++ b/ADVANCED_README.md
@@ -94,25 +94,16 @@ export K8S_CONTEXT='production'
 export K8S_NAMESPACE='my-app'
 ```
 
-### Claude Desktop Configuration with Environment Variables
+### n8n Configuration with Environment Variables
 
-For Claude Desktop with environment variables:
+The server can be started with environment variables set in an n8n Execute Command node:
 
-```json
-{
-  "mcpServers": {
-    "kubernetes-prod": {
-      "command": "npx",
-      "args": ["mcp-server-kubernetes"],
-      "env": {
-        "K8S_SERVER": "https://prod-cluster.example.com",
-        "K8S_TOKEN": "your-token-here",
-        "K8S_CONTEXT": "production",
-        "K8S_NAMESPACE": "my-app"
-      }
-    }
-  }
-}
+```bash
+K8S_SERVER=https://prod-cluster.example.com \
+K8S_TOKEN=your-token-here \
+K8S_CONTEXT=production \
+K8S_NAMESPACE=my-app \
+ENABLE_UNSAFE_SSE_TRANSPORT=1 PORT=3001 npx mcp-server-kubernetes
 ```
 
 ### Non-Destructive Mode
@@ -141,20 +132,10 @@ When enabled, the following destructive operations are disabled:
 
 All read-only operations like listing resources, describing pods, getting logs, etc. remain fully functional.
 
-For Non destructive mode in Claude Desktop, you can specify the env var like this:
+To enable non-destructive mode when running from n8n, set the environment variable:
 
-```json
-{
-  "mcpServers": {
-    "kubernetes-readonly": {
-      "command": "npx",
-      "args": ["mcp-server-kubernetes"],
-      "env": {
-        "ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS": "true"
-      }
-    }
-  }
-}
+```bash
+ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS=true ENABLE_UNSAFE_SSE_TRANSPORT=1 PORT=3001 npx mcp-server-kubernetes
 ```
 
 ### SSE Transport

--- a/README.md
+++ b/README.md
@@ -17,18 +17,19 @@ https://github.com/user-attachments/assets/f25f8f4e-4d04-479b-9ae0-5dac452dd2ed
 
 <a href="https://glama.ai/mcp/servers/w71ieamqrt"><img width="380" height="200" src="https://glama.ai/mcp/servers/w71ieamqrt/badge" /></a>
 
-## Usage with Claude Desktop
+## Usage with n8n
 
-```json
-{
-  "mcpServers": {
-    "kubernetes": {
-      "command": "npx",
-      "args": ["mcp-server-kubernetes"]
-    }
-  }
-}
+You can run the server with the SSE transport enabled and interact with it from
+n8n using HTTP Request nodes. Start the server:
+
+```bash
+ENABLE_UNSAFE_SSE_TRANSPORT=1 PORT=3001 npx mcp-server-kubernetes
 ```
+
+Then use an HTTP Request node in n8n to POST JSON-RPC messages to
+`http://localhost:3001/messages?sessionId=<sessionId>` after retrieving the
+session ID from the `/sse` endpoint. See `src/n8n-client.ts` for a minimal
+example script.
 
 By default, the server loads kubeconfig from `~/.kube/config`. For additional authentication options (environment variables, custom paths, etc.), see [ADVANCED_README.md](ADVANCED_README.md).
 
@@ -39,7 +40,7 @@ The server will automatically connect to your current kubectl context. Make sure
 3. Access to a Kubernetes cluster configured for kubectl (e.g. minikube, Rancher Desktop, GKE, etc.)
 4. Helm v3 installed and in your PATH (no Tiller required). Optional if you don't plan to use Helm.
 
-You can verify your connection by asking Claude to list your pods or create a test deployment.
+You can verify your connection by listing pods or creating a test deployment using the provided tools.
 
 If you have errors open up a standard terminal and run `kubectl get pods` to see if you can connect to your cluster without credentials issues.
 
@@ -51,19 +52,6 @@ If you have errors open up a standard terminal and run `kubectl get pods` to see
 npx mcp-chat --server "npx mcp-server-kubernetes"
 ```
 
-Alternatively, pass it your existing Claude Desktop configuration file from above (Linux should pass the correct path to config):
-
-Mac:
-
-```shell
-npx mcp-chat --config "~/Library/Application Support/Claude/claude_desktop_config.json"
-```
-
-Windows:
-
-```shell
-npx mcp-chat --config "%APPDATA%\Claude\claude_desktop_config.json"
-```
 
 ## Features
 
@@ -140,17 +128,10 @@ npx @modelcontextprotocol/inspector node dist/index.js
 # Follow further instructions on terminal for Inspector link
 ```
 
-5. Local testing with Claude Desktop
+5. Local testing with the n8n client example
 
-```json
-{
-  "mcpServers": {
-    "mcp-server-kubernetes": {
-      "command": "node",
-      "args": ["/path/to/your/mcp-server-kubernetes/dist/index.js"]
-    }
-  }
-}
+```bash
+node ./dist/n8n-client.js
 ```
 
 6. Local testing with [mcp-chat](https://github.com/Flux159/mcp-chat)
@@ -173,20 +154,10 @@ You can run the server in a non-destructive mode that disables all destructive o
 ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS=true npx mcp-server-kubernetes
 ```
 
-For Claude Desktop configuration with non-destructive mode:
+To run n8n in a non-destructive configuration, set the environment variable when starting the server:
 
-```json
-{
-  "mcpServers": {
-    "kubernetes-readonly": {
-      "command": "npx",
-      "args": ["mcp-server-kubernetes"],
-      "env": {
-        "ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS": "true"
-      }
-    }
-  }
-}
+```bash
+ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS=true ENABLE_UNSAFE_SSE_TRANSPORT=1 PORT=3001 npx mcp-server-kubernetes
 ```
 
 ### Commands Available in Non-Destructive Mode

--- a/package.json
+++ b/package.json
@@ -23,13 +23,13 @@
     "test": "vitest run",
     "prepublishOnly": "npm run build",
     "dockerbuild": "docker buildx build -t flux159/mcp-server-kubernetes --platform linux/amd64,linux/arm64 --push .",
-    "chat": "npx mcp-chat --server \"./dist/index.js\""
+    "chat": "npx mcp-chat --server \"./dist/index.js\"",
+    "n8n-client": "node dist/n8n-client.js"
   },
   "keywords": [
     "mcp",
     "kubernetes",
-    "claude",
-    "anthropic",
+    "n8n",
     "kubectl"
   ],
   "engines": {

--- a/src/n8n-client.ts
+++ b/src/n8n-client.ts
@@ -1,0 +1,73 @@
+import fetch from 'node-fetch';
+
+async function main() {
+  const serverUrl = 'http://localhost:3001';
+
+  const sseResponse = await fetch(`${serverUrl}/sse`);
+  if (sseResponse.status !== 200 || !sseResponse.body) {
+    throw new Error('Failed to connect to SSE endpoint');
+  }
+
+  const reader = sseResponse.body.getReader();
+  const decoder = new TextDecoder();
+  let sessionId: string | undefined;
+
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value);
+    const lines = chunk.split('\n');
+    for (const line of lines) {
+      if (line.startsWith('event: endpoint')) {
+        const dataLine = lines[lines.indexOf(line) + 1];
+        const data = dataLine.replace('data: ', '');
+        sessionId = data.split('sessionId=')[1];
+        break;
+      }
+    }
+    if (sessionId) break;
+  }
+
+  if (!sessionId) throw new Error('Unable to obtain session id');
+
+  await fetch(`${serverUrl}/messages?sessionId=${sessionId}`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'kubectl_get',
+        arguments: {
+          resourceType: 'pods',
+          namespace: 'default',
+          output: 'json'
+        }
+      }
+    })
+  });
+
+  let result: any;
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    const chunk = decoder.decode(value);
+    const lines = chunk.split('\n');
+    for (const line of lines) {
+      if (line.startsWith('event: message')) {
+        const dataLine = lines[lines.indexOf(line) + 1];
+        result = JSON.parse(dataLine.replace('data: ', ''));
+        break;
+      }
+    }
+    if (result) break;
+  }
+
+  console.log(JSON.stringify(result, null, 2));
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add n8n usage instructions
- drop references to Claude Desktop
- show how to run in n8n-friendly non-destructive mode
- add n8n client example script
- remove claude keywords from package

## Testing
- `bun run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685e83a57bb48323ac267b50af7ccffa