### PR TITLE
Fix Docker build by using Node fetch

### DIFF
--- a/src/n8n-client.ts
+++ b/src/n8n-client.ts
@@ -1,7 +1,5 @@
 
-import fetch from 'node-fetch';
-
-
+// Use the built-in fetch implementation provided by Node.js
 async function main() {
   const serverUrl = 'http://localhost:3001';
 


### PR DESCRIPTION
## Summary
- remove `node-fetch` import and rely on built-in Node.js fetch to fix `getReader` error

## Testing
- `npm test` *(fails: `vitest: not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685e9a1b7fa48323b0fde97874f8f7ef