### PR TITLE
Update tsconfig libs

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,7 +9,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "declaration": true
+    "declaration": true,
+    "lib": ["ES2022", "DOM"]
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist"]


### PR DESCRIPTION
## Summary
- add DOM library to the TypeScript configuration so `bun run build` no longer produces the `getReader` compile error

## Testing
- `bun run build` *(fails: Cannot find module 'zod' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_685ea6f9e23c8323b71c5ae7903919d0