### PR TITLE
Remove leftover separators

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Kubernetes kümeleriyle iletişim kuran ve onları yöneten bir MCP sunucusu. Ku
 ## n8n ile Kullanım
 
 Sunucuyu SSE taşımacılığı aktif şekilde başlatıp n8n içindeki HTTP Request düğümleri ile iletişim kurabilirsiniz. Sunucuyu çalıştırın:
-=======
+
 ## Usage with n8n
 
 You can run the server with the SSE transport enabled and interact with it from
@@ -30,7 +30,6 @@ ENABLE_UNSAFE_SSE_TRANSPORT=1 PORT=3001 npx mcp-server-kubernetes
 ```
 
 Ardından `/sse` uç noktasından oturum kimliğini aldıktan sonra n8n içinden `http://localhost:3001/messages?sessionId=<sessionId>` adresine JSON-RPC istekleri gönderebilirsiniz. Basit bir örnek için `src/n8n-client.ts` dosyasına bakın.
-=======
 Then use an HTTP Request node in n8n to POST JSON-RPC messages to
 `http://localhost:3001/messages?sessionId=<sessionId>` after retrieving the
 session ID from the `/sse` endpoint. See `src/n8n-client.ts` for a minimal
@@ -46,7 +45,6 @@ Sunucu mevcut kubectl bağlamınızı otomatik olarak kullanır. Şunların kuru
 2. Geçerli bağlamlara sahip bir kubeconfig dosyası
 3. minikube, Rancher Desktop veya GKE gibi bir Kubernetes kümesine erişim
 4. Helm v3 (isteğe bağlı)
-=======
 You can verify your connection by listing pods or creating a test deployment using the provided tools.
 
 Bağlantınızı, sağlanan araçlarla podları listeleyerek veya örnek bir dağıtım oluşturarak doğrulayabilirsiniz.
@@ -100,7 +98,6 @@ Bu işlem Dockerfile üzerinden imajı oluşturur. SSE taşımacılığı varsay
 Sunucu, sık karşılaşılan teşhis işlemleri için özel istemler içerir.
 
 ### k8s-diagnose İstemi
-=======
 
 Bu istem belirli bir anahtar kelime ve isteğe bağlı ad alanı alarak pod sorunlarını sistematik şekilde inceleyen bir akış sunar.
 
@@ -170,7 +167,6 @@ ALLOW_ONLY_NON_DESTRUCTIVE_TOOLS=true npx mcp-server-kubernetes
 
 
 n8n üzerinde de aynı değişkeni kullanarak sunucuyu çalıştırabilirsiniz:
-=======
 To run n8n in a non-destructive configuration, set the environment variable when starting the server:
 
 ```bash


### PR DESCRIPTION
## Summary
- strip `=======` separator lines from README
- ensure text flows smoothly after removal

## Testing
- `bun run test` *(fails: vitest not found)*
- `npm run test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea7066da08323a79926ac4f22dc0d