### PR TITLE
Remove compose version line

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   mcp-server:
     build: .


### PR DESCRIPTION
## Summary
- clean up `docker-compose.yml` by removing the version line

## Testing
- `bun install` *(fails: 403 errors)*
- `bun run test` *(fails: vitest: command not found)*
- `docker compose up` *(fails: docker: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ea7033df883239197cd6d8764833c